### PR TITLE
Add joint impedance control interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(kinova_gen3_control)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
@@ -15,8 +15,11 @@ find_package(catkin REQUIRED
   angles
   roscpp
   control_toolbox
+  kdl_parser
   )
 
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+ 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
@@ -135,6 +138,7 @@ catkin_package(
 include_directories(
  include
  ${catkin_INCLUDE_DIRS}
+ ${EIGEN_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -170,6 +174,7 @@ add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 target_link_libraries(${PROJECT_NAME}_node
    ${KORTEX_DIR}lib/release/libKortexApiCpp.a
    ${catkin_LIBRARIES}
+   Eigen3::Eigen
 )
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ find_package(catkin REQUIRED
   joint_limits_interface 
   controller_manager
   angles
-  roscpp)
+  roscpp
+  control_toolbox
+  )
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,21 +136,23 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(${PROJECT_NAME}
-  src/${PROJECT_NAME}/kinova_gen3_hardware_interface.cpp
-  src/${PROJECT_NAME}/kinova_gen3_network_connection.cpp
-  src/${PROJECT_NAME}/fake_kinova_network_connection.cpp
-)
+## add_library(${PROJECT_NAME}
+## )
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+## add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-add_executable(${PROJECT_NAME}_node src/kinova_gen3_hardware_interface_node.cpp)
+add_executable(${PROJECT_NAME}_node
+  src/${PROJECT_NAME}/kinova_gen3_hardware_interface.cpp
+  src/${PROJECT_NAME}/kinova_gen3_network_connection.cpp
+  src/${PROJECT_NAME}/fake_kinova_network_connection.cpp
+  src/kinova_gen3_hardware_interface_node.cpp
+  )
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -164,7 +166,6 @@ add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node
-   ${PROJECT_NAME}
    ${KORTEX_DIR}lib/release/libKortexApiCpp.a
    ${catkin_LIBRARIES}
 )

--- a/config/kinova_gen3_hardware_interface.yaml
+++ b/config/kinova_gen3_hardware_interface.yaml
@@ -1,0 +1,9 @@
+# Joint impedance configuration
+joint_impedance:
+    joint_1: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_2: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_3: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_4: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_5: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_6: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
+    joint_7: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}

--- a/config/kinova_gen3_hardware_interface.yaml
+++ b/config/kinova_gen3_hardware_interface.yaml
@@ -1,4 +1,6 @@
 # Joint impedance configuration
+robot_base_link: "base_link"
+robot_tip_link: "end_effector_link"
 joint_impedance:
     joint_1: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}
     joint_2: {p: 10.0, i: 0.0, d: 1.0, i_clamp_min: -1.0, i_clamp_max: 1.0}

--- a/include/kinova_gen3_control/kinova_gen3_hardware_interface.h
+++ b/include/kinova_gen3_control/kinova_gen3_hardware_interface.h
@@ -7,6 +7,7 @@
 #include <BaseClientRpc.h>
 #include <BaseCyclicClientRpc.h>
 #include <ActuatorConfigClientRpc.h>
+#include <control_toolbox/pid.h>
 
 #include <joint_limits_interface/joint_limits_interface.h>
 
@@ -36,12 +37,17 @@ class KinovaGen3HardwareInterface : public hardware_interface::RobotHW
     std::vector<joint_limits_interface::JointLimits> limits_;
     hardware_interface::JointStateInterface jnt_state_interface_;
     hardware_interface::EffortJointInterface jnt_eff_interface_;
-    joint_limits_interface::EffortJointSaturationInterface jnt_eff_limit_interface_;
+    hardware_interface::PositionJointInterface jnt_pos_interface_;
+    hardware_interface::EffortJointInterface jnt_cmd_interface_;
+    joint_limits_interface::EffortJointSaturationInterface jnt_cmd_limit_interface_;
     // no need to re-create this object every time it's used
     Kinova::Api::BaseCyclic::Feedback base_feedback_;
+    double eff_cmd_[NUMBER_OF_JOINTS];
+    double pos_cmd_[NUMBER_OF_JOINTS];
     double cmd_[NUMBER_OF_JOINTS];
     double pos_[NUMBER_OF_JOINTS];
     double vel_[NUMBER_OF_JOINTS];
     double eff_[NUMBER_OF_JOINTS];
+    std::vector<control_toolbox::Pid> pid_controllers_;
 };
 #endif // KINOVA_GEN3_HARDWARE_INTERFACE_H 

--- a/include/kinova_gen3_control/kinova_gen3_hardware_interface.h
+++ b/include/kinova_gen3_control/kinova_gen3_hardware_interface.h
@@ -8,6 +8,8 @@
 #include <BaseCyclicClientRpc.h>
 #include <ActuatorConfigClientRpc.h>
 #include <control_toolbox/pid.h>
+#include <kdl/chainidsolver_recursive_newton_euler.hpp>
+#include <kdl/chain.hpp>
 
 #include <joint_limits_interface/joint_limits_interface.h>
 
@@ -49,5 +51,7 @@ class KinovaGen3HardwareInterface : public hardware_interface::RobotHW
     double vel_[NUMBER_OF_JOINTS];
     double eff_[NUMBER_OF_JOINTS];
     std::vector<control_toolbox::Pid> pid_controllers_;
+    std::unique_ptr<KDL::ChainIdSolver_RNE> dynamics_solver_;
+    KDL::Chain robot_chain_;
 };
 #endif // KINOVA_GEN3_HARDWARE_INTERFACE_H 

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="debug" default="false"/>
+  <arg if="$(arg debug)" name="launch-prefix" value="screen -d -m gdb -command=$(env HOME)/.ros/my_debug_log --ex run --args"/>
+  <arg unless="$(arg debug)" name="launch-prefix" value=""/>
+
   <arg name="use_local_control_computer" default="true"/>
   <arg name="fake_connection" default="false"/>
   <arg name="control_loop_hz" default="500"/>
@@ -44,7 +48,7 @@
      output="screen" args="load $(arg controllers_to_load)"/>
 
   <node machine="control-computer" name="kinova_gen3_hardware_interface_node" pkg="kinova_gen3_control" type="kinova_gen3_control_node" respawn="false"
-    output="screen">
+    output="screen" launch-prefix="$(arg launch-prefix)">
     <param name="fake_connection" value="$(arg fake_connection)"/>
     <param name="control_loop_hz" value="$(arg control_loop_hz)"/>
   </node>

--- a/launch/default.launch
+++ b/launch/default.launch
@@ -51,5 +51,6 @@
     output="screen" launch-prefix="$(arg launch-prefix)">
     <param name="fake_connection" value="$(arg fake_connection)"/>
     <param name="control_loop_hz" value="$(arg control_loop_hz)"/>
+    <rosparam file="$(find kinova_gen3_control)/config/kinova_gen3_hardware_interface.yaml"/>
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
   <depend>xacro</depend>
   <depend>ros_controllers</depend>
   <depend>kortex_description</depend>
+  <depend>control_toolbox</depend>
   <buildtool_depend>catkin</buildtool_depend>
 
 

--- a/package.xml
+++ b/package.xml
@@ -34,6 +34,7 @@
   <depend>ros_controllers</depend>
   <depend>kortex_description</depend>
   <depend>control_toolbox</depend>
+  <depend>kdl_parser</depend>
   <buildtool_depend>catkin</buildtool_depend>
 
 


### PR DESCRIPTION
## Goal
Implement a joint-level impedance control interface for this robot. Support
controller switches between effort and position controllers without restarting the control node
 
## Motivation
Many control pipelines work with position-based ROS-controllers. It feels natural for the RobotHW to provide a `PositionJointInterface` while offering some joint-level compliance. 

## Approach
Command both `position` and `torques` via an impedance law
  - [x] Use meaningful default values for joint position commands in the read() method, such as current data
  - [x] Use gravity/dynamics compensation by default. This allows us to avoid sending the [currently measured torques as default effort commands](https://github.com/stefanscherzinger/kinova_gen3_control/blob/master/src/kinova_gen3_control/kinova_gen3_hardware_interface.cpp#L201)
  - [x] Think of additional effort commands as feedforward torques that default to zero if not set by the controllers
  - [x] Use `realtime_tools` to implement joint-level PID controllers for rendering the _impedance behavior_.
  - [ ] Override the default resource handling to support both `PositionJointInterface` and `EffortJointInterface` in parallel (does that make sense?)

